### PR TITLE
Make it explicit that user agents can modify or omit hints

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -230,9 +230,9 @@ following steps:
  <ol>
    <li>If |request| is not a [=navigation request=] for a "document" [=request/destination=] and if the result of running [[permissions-policy#algo-should-request-be-allowed-to-use-feature]]
    given |request| and |hintName|'s associated feature in [[#policy-controlled-features]] returns `false`, then continue to next |hintName|.
-   <li>If the user agent decides, in an [=implementation defined=] way (see [[#privacy]]), to omit this hint then continue.
+   <li>If the user agent decides, in an [=implementation-defined=] way (see [[#privacy]]), to omit this hint then continue.
    <li>Let |value| be the result of running [=find client hint value=] with |hintName|.
-   <li>If the user agent decides, in an [=implementation defined=] way (see [[#privacy]]), to modify |value| then do so.
+   <li>If the user agent decides, in an [=implementation-defined=] way (see [[#privacy]]), to modify |value| then do so.
    <li>[=header list/append=] |hintName|/|value| to the [=request/header list=].
  </ol>
 </ol>


### PR DESCRIPTION
This is addressing feedback from https://github.com/WebKit/standards-positions/issues/20#issuecomment-1172062942:
- Fix bug in Request processing algo
- Clarify UAs need not support all client hints to adopt standard

closes #120


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/pull/121.html" title="Last updated on Jul 6, 2022, 12:04 PM UTC (924181c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/121/5251c9b...924181c.html" title="Last updated on Jul 6, 2022, 12:04 PM UTC (924181c)">Diff</a>