### PR TITLE
Correct Client Hint header links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -496,15 +496,15 @@ When asked to <dfn>find client hint value</dfn>, given |hint| as input, switch o
   <dt>`Save-Data`
   <dd>a suitable <a href="https://wicg.github.io/savedata/#save-data-request-header-field">Save-Data value</a>
   <dt>`DPR`
-  <dd>a suitable <a href>DPR value</a>
+  <dd>a suitable <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-dpr">DPR value</a>
   <dt>`Viewport-Width`
-  <dd>a suitable <a href>Viewport-Width value</a>
+  <dd>a suitable <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width">Viewport-Width value</a>
   <dt>`Viewport-Height`
   <dd>a suitable <a href>Viewport-Height value</a>
   <dt>`Width`
-  <dd>a suitable <a href>Width value</a>
+  <dd>a suitable <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-width">Width value</a>
   <dt>`Device-Memory`
-  <dd>a suitable <a href="https://w3c.github.io/device-memory/#sec-device-memory-client-hint-header">Device-Memory value</a>
+  <dd>a suitable <a href="https://www.w3.org/TR/device-memory/#sec-device-memory-client-hint-header">Device-Memory value</a>
   <dt>`RTT`
   <dd>a suitable <a href="https://wicg.github.io/netinfo/#rtt-request-header-field">RTT value</a>
   <dt>`Downlink`

--- a/index.bs
+++ b/index.bs
@@ -500,7 +500,7 @@ When asked to <dfn>find client hint value</dfn>, given |hint| as input, switch o
   <dt>`Viewport-Width`
   <dd>a suitable <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-width">Viewport-Width value</a>
   <dt>`Viewport-Height`
-  <dd>a suitable <a href>Viewport-Height value</a>
+  <dd>a suitable <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-viewport-height">Viewport-Height value</a>
   <dt>`Width`
   <dd>a suitable <a href="https://wicg.github.io/responsive-image-client-hints/#sec-ch-width">Width value</a>
   <dt>`Device-Memory`


### PR DESCRIPTION
Fixes #166 

Looks like this was broken in #13


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tunetheweb/client-hints-infrastructure/pull/167.html" title="Last updated on Mar 30, 2026, 10:37 PM UTC (fa23609)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/client-hints-infrastructure/167/6150bc0...tunetheweb:fa23609.html" title="Last updated on Mar 30, 2026, 10:37 PM UTC (fa23609)">Diff</a>